### PR TITLE
Feature/update-specialization-list-endpoint

### DIFF
--- a/app/Annotations/OpenApi/controllersAnnotations/specializationListAnnotations/AnnotationsSpecializationList.php
+++ b/app/Annotations/OpenApi/controllersAnnotations/specializationListAnnotations/AnnotationsSpecializationList.php
@@ -9,11 +9,11 @@ class AnnotationsSpecializationList
     /**
      * @OA\Get(
      *     path="/api/v1/specialization/list",
-     *     summary="Specialization list",
+     *     summary="Retrieve a specialization list from resume model enum",
      *     tags={"Specialization"},
      *     @OA\Response(
      *         response=200,
-     *         description="Successful. Specialization list retrieved",
+     *         description="Successful. Specialization list retrieved from enum",
      *         @OA\JsonContent(
      *             type="array",
      *             @OA\Items(type="string")

--- a/app/Http/Controllers/api/SpecializationListController.php
+++ b/app/Http/Controllers/api/SpecializationListController.php
@@ -9,7 +9,6 @@ class SpecializationListController extends Controller
 {
     public function __invoke()
     {
-        // Retrieve unique specialization codes from the Resume model excluding 'Not Set'
         $specialization_list = Resume::distinct()
             ->where('specialization', '!=', 'Not Set')
             ->pluck('specialization')


### PR DESCRIPTION
Specialization list controller update:

Now the controller retrieves the list from the resume model enum.

The list has all its content except for the "Not Set" element.