### PR TITLE
234 fe add a toast with console errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,8 +22,9 @@
         "react-i18next": "13.5.0",
         "react-redux": "8.1.3",
         "react-router-dom": "^6.24.0",
+        "react-toastify": "^10.0.5",
         "uuid": "^9.0.1",
-        "watch": "^1.0.2",
+        "watch": "^0.13.0",
         "zod": "3.22.4"
       },
       "devDependencies": {
@@ -33,6 +34,7 @@
         "@types/js-cookie": "3.0.6",
         "@types/react": "18.2.15",
         "@types/react-dom": "18.2.7",
+        "@types/react-toastify": "^4.1.0",
         "@types/uuid": "^9.0.8",
         "@typescript-eslint/eslint-plugin": "7.5.0",
         "@typescript-eslint/parser": "7.5.0",
@@ -1707,6 +1709,17 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/react-toastify": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@types/react-toastify/-/react-toastify-4.1.0.tgz",
+      "integrity": "sha512-u7Ie/7LHBsPVz/iJxi/WlRDS7Gh9csCJACTDXx+pSLuZCm94xpkwzhM3jV1L5ZxP/in0Gp2tFbJ91VrSGr1gyQ==",
+      "deprecated": "This is a stub types definition. react-toastify provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-toastify": "*"
+      }
+    },
     "node_modules/@types/scheduler": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.23.0.tgz",
@@ -2837,6 +2850,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -4322,14 +4344,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/exec-sh": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
-      "integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
-      "dependencies": {
-        "merge": "^1.2.0"
       }
     },
     "node_modules/execa": {
@@ -6511,11 +6525,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/merge": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
-      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ=="
-    },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -7821,6 +7830,19 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-10.0.5.tgz",
+      "integrity": "sha512-mNKt2jBXJg4O7pSdbNUfDdTsK9FIdikfsIE/yUCxbAEXl4HMyJaivrVFcn3Elvt5xvCQYhUZm+hqTIu1UXM3Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/read-cache": {
@@ -9380,18 +9402,17 @@
       }
     },
     "node_modules/watch": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/watch/-/watch-1.0.2.tgz",
-      "integrity": "sha512-1u+Z5n9Jc1E2c7qDO8SinPoZuHj7FgbgU1olSFoyaklduDvvtX7GMMtlE6OC9FTXq4KvNAOfj6Zu4vI1e9bAKA==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/watch/-/watch-0.13.0.tgz",
+      "integrity": "sha512-yTgNlr/8OjaGYq2FIv/PjU0zlv/pdAOmVSEeHNVcApFTT6ocWnMLhXlB6n/Rz9VVWXZmZkvkDnJ+iAIi/JjUJA==",
+      "engines": [
+        "node >=0.1.95"
+      ],
       "dependencies": {
-        "exec-sh": "^0.2.0",
-        "minimist": "^1.2.0"
+        "minimist": "^1.1.0"
       },
       "bin": {
         "watch": "cli.js"
-      },
-      "engines": {
-        "node": ">=0.1.95"
       }
     },
     "node_modules/webidl-conversions": {
@@ -9584,10 +9605,11 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
-      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -27,8 +27,9 @@
     "react-i18next": "13.5.0",
     "react-redux": "8.1.3",
     "react-router-dom": "^6.24.0",
+    "react-toastify": "^10.0.5",
     "uuid": "^9.0.1",
-    "watch": "^1.0.2",
+    "watch": "^0.13.0",
     "zod": "3.22.4"
   },
   "devDependencies": {
@@ -38,6 +39,7 @@
     "@types/js-cookie": "3.0.6",
     "@types/react": "18.2.15",
     "@types/react-dom": "18.2.7",
+    "@types/react-toastify": "^4.1.0",
     "@types/uuid": "^9.0.8",
     "@typescript-eslint/eslint-plugin": "7.5.0",
     "@typescript-eslint/parser": "7.5.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,7 @@ const App = () => {
           </Route>
         </Routes>
       </BrowserRouter>
-      {process.env.NODE_ENV && <ToastContainer />}
+      {process.env.NODE_ENV === 'development' && <ToastContainer />}
     </SmallScreenProvider>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,24 +1,33 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom'
+import { useEffect } from 'react'
+import { ToastContainer } from 'react-toastify'
 import SmallScreenProvider from './context/SmallScreenContext'
 import Home from './pages/Home'
 import StudentProfilePage from './pages/StudentProfilePage'
 import './styles/App.css'
+import 'react-toastify/dist/ReactToastify.css';
 import ProtectedRoute from './utils/ProtectedRoutes'
 import { useLogin } from './context/LoginContext'
+import toastConsoleErrorListener from './lib/utils/toastConsoleErrorListener'
 
 const App = () => {
   const { isLoggedIn } = useLogin();
+
+  useEffect(() => {
+    toastConsoleErrorListener()
+  }, [])
 
   return (
     <SmallScreenProvider>
       <BrowserRouter>
         <Routes>
-          <Route path='/' element={<Home />}/>
+          <Route path='/' element={<Home />} />
           <Route element={<ProtectedRoute canActivate={isLoggedIn} redirectPath='/' />}>
             <Route path='/profile' element={<StudentProfilePage />} />
           </Route>
         </Routes>
       </BrowserRouter>
+      <ToastContainer />
     </SmallScreenProvider>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,7 @@ const App = () => {
           </Route>
         </Routes>
       </BrowserRouter>
-      <ToastContainer />
+      {process.env.NODE_ENV && <ToastContainer />}
     </SmallScreenProvider>
   );
 };

--- a/src/lib/utils/toastConsoleErrorListener.ts
+++ b/src/lib/utils/toastConsoleErrorListener.ts
@@ -1,0 +1,26 @@
+/* eslint-disable func-names */
+import { toast } from "react-toastify";
+
+const toastConsoleErrorListener = (): void => {
+
+    const toastConsoleError = globalThis.console.error;
+
+    globalThis.console.error = function (message, ...params): void {
+        // Display the error message in a toast notification
+        toast.error(message, {
+            className: "toast-error",
+            autoClose: 5000,
+            closeButton: false,
+            bodyClassName: "toast-body",
+            progressClassName: "toast-progress",
+            position: "bottom-left",
+            draggable: false,
+            pauseOnHover: true,
+        });
+        // Call the original function console.error
+        toastConsoleError.apply(console, [message, params])
+    }
+
+}
+
+export default toastConsoleErrorListener;


### PR DESCRIPTION
Install [react-toastify](https://www.npmjs.com/package/react-toastify).
Install  --save-dev @types/react-toastify 
To display console errors on screen.

![toast-errors](https://github.com/user-attachments/assets/1aaab58a-7d0f-460d-b2e2-c9db1ccdc5ac)
