### PR TITLE
Hotfix migrations for rollback: drop recruiters & drop admins

### DIFF
--- a/database/migrations/2024_04_09_105121_create_additional_trainings_table.php
+++ b/database/migrations/2024_04_09_105121_create_additional_trainings_table.php
@@ -3,7 +3,6 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Support\Facades\DB;
 
 class CreateAdditionalTrainingsTable extends Migration
 {

--- a/database/migrations/2024_04_19_103044_create_collaborations_table.php
+++ b/database/migrations/2024_04_19_103044_create_collaborations_table.php
@@ -3,7 +3,6 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Support\Facades\DB;
 
 class CreateCollaborationsTable extends Migration
 {

--- a/database/migrations/2024_05_23_105104_restructure_users_table_using_uuid.php
+++ b/database/migrations/2024_05_23_105104_restructure_users_table_using_uuid.php
@@ -3,8 +3,6 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Str;
 
 return new class extends Migration
 {

--- a/database/migrations/2024_07_10_093729_drop_recruiters_table.php
+++ b/database/migrations/2024_07_10_093729_drop_recruiters_table.php
@@ -21,7 +21,8 @@ return new class extends Migration
   {
     Schema::create('recruiters', function (Blueprint $table) {
       $table->id();
-      $table->foreignId('user_id')->constrained()->onDelete('cascade')->onUpdate('cascade');
+      $table->uuid('user_id')->index()->nullable();
+      $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
       $table->string('company');
       $table->string('sector');
       $table->timestamps();

--- a/database/migrations/2024_07_10_094805_drop_admins_column.php
+++ b/database/migrations/2024_07_10_094805_drop_admins_column.php
@@ -21,7 +21,7 @@ return new class extends Migration
   {
     Schema::create('admins', function (Blueprint $table) {
       $table->id();
-      $table->unsignedBigInteger('user_id');
+      $table->uuid('user_id');
       $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade')->onUpdate('cascade');
       $table->timestamps();
     });


### PR DESCRIPTION
- Corrected drop recruiters & drop admins migrations for rollback to work.
- Removed unused imports in three other migrations.