### PR TITLE
390 be create job offers via artisan command new branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,42 @@ Below is a list of commands developed for the project, including their descripti
 | Command Name        | Description                                         | Command Help                                      |
 |---------------------|-----------------------------------------------------|-------------------------------------------------|
 | `create:company`   | Creates a new company in the database.            | `create:company --help` |
-| 
+|  `create:job-offer`   | Allows recruiters to create job offers via terminal input. | `create:job-offer --help`  |
+
+#### Using the `create:job-offer` Command  
+
+This command allows recruiters to create job offers directly through the terminal. Here’s how to use it:  
+
+1. Execute the following command to begin creating a job offer:  
+
+   ```bash
+   docker exec -it php php artisan create:job-offer
+
+2. Provide the required information:
+
+ - Recruiter ID: Provide the unique recruiter identifier.
+ - Job Title: E.g., Senior Backend Developer.
+ - Job Description: E.g., Looking for an experienced Backend Developer.
+ - Location: E.g., Barcelona.
+ - Salary (Optional): E.g., 25000 - 35000.
+ - Skills (Optional): E.g., PHP, Laravel, MySQL, MongoDB.
+
+3. Review and confirm: 
+The system will display a preview of the job offer details and ask for confirmation to proceed. If the data is valid, the job offer will be created. Otherwise, you can retry with corrected information.
+
+Example output:
+
+```shell
+    Vista prèvia de l'oferta de treball:
+    - recruiter_id: 1
+    - title: Senior Backend Developer
+    - description: Looking for an experienced Backend Developer
+    - location: Barcelona
+    - salary: 25000 - 35000
+    - skills: PHP, Laravel, MySQL
+
+    Vols procedir amb aquestes dades? (yes/no) [yes]
+```
 
 ## Screenshots
 

--- a/app/Console/Commands/CreateJobOfferCommand.php
+++ b/app/Console/Commands/CreateJobOfferCommand.php
@@ -117,23 +117,25 @@ class CreateJobOfferCommand extends Command
 
         $skills = $this->argument('skills') ?? $this->ask('Introdueix les habilitats requerides (opcional, separades per comes o "cancel")');
 
-        if (strtolower($skills) === 'cancel') {
+        if ($skills !== null && strtolower($skills) === 'cancel') {
             $this->info('Operació cancel·lada.');
             exit(0);
         }
-
-        if (!empty($skills)) {
+        
+        if ($skills !== null && trim($skills) !== '') {
             $validator = Validator::make(
                 ['skills' => $skills],
                 ['skills' => (new CreateJobOfferRequest(app(), app('redirect')))->rules()['skills']]
             );
-
+        
             if ($validator->fails()) {
                 $this->error("Error en habilitats: " . $validator->errors()->first('skills'));
                 $data['skills'] = null;
             } else {
                 $data['skills'] = $skills;
             }
+        } else {
+            $data['skills'] = null;
         }
 
         return $data;

--- a/app/Console/Commands/CreateJobOfferCommand.php
+++ b/app/Console/Commands/CreateJobOfferCommand.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
+use App\Http\Requests\Job\CreateJobOfferRequest;
+use Symfony\Component\Console\Input\InputArgument;
+use App\Http\Controllers\Api\Job\JobOfferController;
+
+class CreateJobOfferCommand extends Command
+{
+
+    protected $description = 'Create a new job offer in the database giving the required arguments step by step in terminal.' . PHP_EOL . '  Example:
+    Recruiter ID: Provide the unique recruiter identifiere
+    Title: Senior Backend Developer
+    Description: Looking for an experienced Backend Developer
+    Location: Barcelona
+    Salary: 55000
+    Skills: PHP, Laravel, MySQL, MongoDB (Optional)';
+
+    protected $jobOfferController;
+
+    public function __construct(JobOfferController $jobOfferController)
+    {
+        parent::__construct();
+        $this->jobOfferController = $jobOfferController;
+    }
+    protected function configure()
+    {
+        $this->setName('create:job-offer')
+            ->addArgument('recruiter_id', InputArgument::OPTIONAL, 'The ID of the recruiter')
+            ->addArgument('title', InputArgument::OPTIONAL, 'The title of the job offer')
+            ->addArgument('description', InputArgument::OPTIONAL, 'The description of the job offer')
+            ->addArgument('location', InputArgument::OPTIONAL, 'The location of the job offer')
+            ->addArgument('salary', InputArgument::OPTIONAL, 'The salary for the job offer')
+            ->addArgument('skills', InputArgument::OPTIONAL, 'The skills required for the job offer (Optional)');
+    }
+
+    public function handle()
+    {
+        $data = $this->collectValidatedJobOfferData();
+        $this->info("Vista prèvia de l'oferta de treball:");
+        foreach ($data as $key => $value) {
+            $this->line("- {$key}: {$value}");
+        }
+        if (!$this->confirm('Vols procedir amb aquestes dades?', true)) {
+            $this->info('Operació cancel·lada.');
+            return 1;
+        }
+        try {
+
+            $request = $this->createRequest($data);
+            $response = $this->jobOfferController->createJobOffer($request);
+            $this->handleResponse($response);
+            return 0;
+        } catch (ValidationException $e) {
+            $this->handleValidationException($e);
+            return 1;
+        }
+    }
+
+    protected function collectValidatedJobOfferData(): array
+    {
+        $data = [];
+        $maxAttempts = 3;
+
+        $fields = [
+            'recruiter_id' => 'Introdueix l\'ID del reclutador',
+            'title' => 'Introdueix el títol de l\'oferta de feina (ex: Senior Frontend Developer)',
+            'description' => 'Introdueix la descripció de l\'oferta de feina (ex: Seeking a creative developer.)',
+            'location' => 'Introdueix la ubicació de l\'oferta de feina (ex: Barcelona)',
+            'salary' => 'Introdueix el sou de l\'oferta de feina (opcional ex: 25000 - 35000)',
+        ];
+
+        foreach ($fields as $field => $prompt) {
+            $attempts = 0;
+            do {
+                $value = $this->argument($field) ?? $this->ask($prompt . "\n(o escriu 'cancel' per sortir)");
+
+                if ($value !== null && strtolower($value) === 'cancel') {
+                    $this->info('Operació cancel·lada.');
+                    exit(0);
+                }
+
+                $rules = (new CreateJobOfferRequest(app(), app('redirect')))->rules();
+
+
+                if ($field === 'recruiter_id') {
+                    $validator = Validator::make(
+                        [$field => $value],
+                        [$field => 'required|exists:recruiters,id']
+                    );
+                } else {
+                    $validator = Validator::make(
+                        [$field => $value],
+                        [$field => $rules[$field]]
+                    );
+                }
+
+                if ($validator->fails()) {
+                    $this->error("Error en {$field}: " . $validator->errors()->first($field));
+                    $attempts++;
+                    if ($attempts >= $maxAttempts) {
+                        $this->error('Has superat el nombre màxim d\'intents. Reinicia el procés.');
+                        exit(1);
+                    }
+                } else {
+                    $data[$field] = $value;
+                    break;
+                }
+            } while (true);
+        }
+
+        $skills = $this->argument('skills') ?? $this->ask('Introdueix les habilitats requerides (opcional, separades per comes o "cancel")');
+
+        if (strtolower($skills) === 'cancel') {
+            $this->info('Operació cancel·lada.');
+            exit(0);
+        }
+
+        if (!empty($skills)) {
+            $validator = Validator::make(
+                ['skills' => $skills],
+                ['skills' => (new CreateJobOfferRequest(app(), app('redirect')))->rules()['skills']]
+            );
+
+            if ($validator->fails()) {
+                $this->error("Error en habilitats: " . $validator->errors()->first('skills'));
+                $data['skills'] = null;
+            } else {
+                $data['skills'] = $skills;
+            }
+        }
+
+        return $data;
+    }
+
+    protected function createRequest(array $data): CreateJobOfferRequest
+    {
+        $request = new CreateJobOfferRequest(app(), app('redirect'));
+
+        if (empty($data['skills'])) {
+            unset($data['skills']);
+        }
+        $request->merge($data);
+        $request->validateResolved();
+        return $request;
+    }
+    protected function handleResponse($response)
+    {
+        $content = $response->getData(true);
+
+        if (isset($content['message'])) {
+            $this->info($content['message']);
+        }
+
+        if (isset($content['jobOffer'])) {
+            $this->line("Detalls de l'oferta:");
+            foreach ($content['jobOffer'] as $key => $value) {
+                $this->line("- {$key}: {$value}");
+            }
+        }
+    }
+    protected function handleValidationException(ValidationException $e)
+    {
+        foreach ($e->errors() as $field => $messages) {
+            foreach ($messages as $message) {
+                $this->error("Error en el camp {$field}: {$message}");
+            }
+        }
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -7,6 +7,15 @@ use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 
 class Kernel extends ConsoleKernel
 {
+        /**
+     * The Artisan commands provided by your application.
+     *
+     * @var array
+     */
+    protected $commands = [
+        \App\Console\Commands\CreateJobOfferCommand::class,
+    ];
+    
     protected function schedule(Schedule $schedule): void
     {
         $schedule->command('project:execute-project-processing-service')

--- a/app/Http/Controllers/api/Job/JobOfferController.php
+++ b/app/Http/Controllers/api/Job/JobOfferController.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\api\Job;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Job\CreateJobOfferRequest;
+use App\Models\JobOffer;
+
+
+class JobOfferController extends Controller
+{
+
+    public function createJobOffer(CreateJobOfferRequest $request)
+    {
+        $jobOffer = JobOffer::create($request->validated());
+
+        return response()->json(['message' => 'Oferta de feina creada amb èxit', 'jobOffer' => $jobOffer], 201);
+    }
+}

--- a/app/Http/Requests/Job/CreateJobOfferRequest.php
+++ b/app/Http/Requests/Job/CreateJobOfferRequest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Job;
+
+use Illuminate\Container\Container;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Routing\Redirector;
+
+
+class CreateJobOfferRequest extends FormRequest
+{
+    protected $container;
+    protected $redirector;
+
+    public function __construct(Container $container, Redirector $redirector)
+    {
+        parent::__construct();
+        $this->container = $container;
+        $this->redirector = $redirector;
+    }
+
+
+    public function authorize()
+    {
+        return true; 
+    }
+
+    public function rules()
+    {
+        return [
+            'recruiter_id' => 'required|exists:recruiters,id',
+            'title' => 'required|string|max:255',
+            'description' => 'required|string|max:255',
+            'location' => 'required|string|max:255',
+            'salary' => 'nullable|string|max:255',
+            'skills' => 'nullable|string',
+        ];
+    }
+    public function messages()
+    {
+        return [
+            'recruiter_id.required' => 'El camp recruiter_id és obligatori.',
+            'recruiter_id.exists' => 'El recruiter_id ha de correspondre a un reclutador existent.',
+
+            'title.required' => 'El camp títol és obligatori.',
+            'title.max' => 'El títol no pot tenir més de 255 caràcters.',
+
+            'description.required' => 'El camp descripció és obligatori.',
+            'description.max' => 'La descripció no pot tenir més de 255 caràcters.',
+
+            'location.required' => 'El camp ubicació és obligatori.',
+            'location.max' => 'La ubicació no pot tenir més de 255 caràcters.',
+
+            'salary.max' => 'El salari no pot tenir més de 255 caràcters.',
+
+            'skills.max' => 'Les habilitats no poden superar els 255 caràcters.',
+            
+            
+        ];
+    }
+    
+    public function validateRecruiterIdField()
+    {
+        $this->validate([
+            'recruiter_id' => $this->rules()['recruiter_id']
+        ]);
+    }
+
+    public function validateTitleField()
+    {
+        $this->validate([
+            'title' => $this->rules()['title']
+        ]);
+    }
+
+    public function validateDescriptionField()
+    {
+        $this->validate([
+            'description' => $this->rules()['description']
+        ]);
+    }
+
+    public function validateLocationField()
+    {
+        $this->validate([
+            'location' => $this->rules()['location']
+        ]);
+    }
+
+    public function validateSalaryField()
+    {
+        $this->validate([
+            'salary' => $this->rules()['salary']
+        ]);
+    }
+
+    public function validateSkillsField()
+    {
+        $this->validate([
+            'skills' => $this->rules()['skills']
+        ]);
+    }
+
+    public function validateAllFields()
+    {
+        $this->validate($this->rules());
+    }
+    
+}

--- a/database/migrations/2024_11_11_215429_create_job_offers_table.php
+++ b/database/migrations/2024_11_11_215429_create_job_offers_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
             $table->text('description');
             $table->string('location', 255);
             $table->string('skills', 255)->nullable();
-            $table->string('salary', 255);
+            $table->string('salary', 255)->nullable();
             $table->timestamps();
 
             $table->foreign('recruiter_id')

--- a/tests/Feature/Console/Commands/CreateJobOfferByCommandTest.php
+++ b/tests/Feature/Console/Commands/CreateJobOfferByCommandTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console\Commands;
+
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\Company;
+use App\Models\JobOffer;
+use App\Models\Recruiter;
+use Illuminate\Foundation\Testing\WithFaker;
+use App\Http\Controllers\api\Job\JobOfferController;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\Unit\Model\Job\JobOfferModelTest; 
+use Tests\Feature\Controller\Job\JobOfferControllerTest;
+
+class CreateJobOfferByCommandTest extends TestCase
+{
+    use DatabaseTransactions;
+    use WithFaker;
+
+    protected Recruiter $recruiter;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $user = User::factory()->create();
+        $company = Company::factory()->create();
+
+        $this->recruiter = Recruiter::factory()->create([
+            'user_id' => $user->id,
+            'company_id' => $company->id
+        ]);
+    }
+
+    public function testIfJobOfferModelExists(): void
+    {
+        $jobOfferModel = new JobOffer();
+    
+        $this->assertInstanceOf(JobOffer::class, $jobOfferModel);
+    }
+    
+    public function testIfJobOfferControllerExists(): void
+    {
+        $jobOfferController = new JobOfferController();
+    
+        $this->assertInstanceOf(JobOfferController::class, $jobOfferController);
+    }
+
+    /**
+     * @dataProvider invalidDataProvider
+     */
+    public function testInvalidJobOffer($invalidData): void
+    {
+        $maxAttempts = 3; 
+        $exceptionThrown = false;
+
+        for ($attempts = 0; $attempts < $maxAttempts; $attempts++) {
+            try {
+                $this->artisan('create:job-offer')
+                    ->expectsQuestion('Introdueix l\'ID del reclutador', $this->recruiter->id)
+                    ->expectsQuestion('Introdueix el títol de l\'oferta', $invalidData['title'])
+                    ->expectsQuestion('Introdueix la descripció de l\'oferta', $invalidData['description'])
+                    ->expectsQuestion('Introdueix la ubicació', $invalidData['location'])
+                    ->expectsQuestion('Introdueix el salari', $invalidData['salary'] ?? '')
+                    ->expectsQuestion('Introdueix les habilitats requerides (opcional, separades per comes)', '')
+                    ->assertExitCode(1);
+                
+                
+                $this->fail('Expected an exception to be thrown for invalid data: ' . json_encode($invalidData));
+            } catch (\Exception $e) {
+                
+                $exceptionThrown = true;
+                break;
+            }
+        }
+
+        $this->assertTrue($exceptionThrown, 'No se lanzó la excepción esperada para datos inválidos');
+    }
+
+    public static function invalidDataProvider(): array
+    {
+        return [
+            'invalid title: too long' => [[
+                'title' => str_repeat('A', 256),
+                'description' => 'Valid Description',
+                'location' => 'Valid Location',
+                'salary' => '50000',
+            ]],
+            'invalid title: empty' => [[
+                'title' => '',
+                'description' => 'Valid Description',
+                'location' => 'Valid Location',
+                'salary' => '50000',
+            ]],
+            'invalid description: too long' => [[
+                'title' => 'Valid Job',
+                'description' => str_repeat('A', 256),
+                'location' => 'Valid Location',
+                'salary' => '50000',
+            ]],
+            'invalid description: empty' => [[
+                'title' => 'Valid Job',
+                'description' => '',
+                'location' => 'Valid Location',
+                'salary' => '50000',
+            ]],
+            'invalid location: empty' => [[
+                'title' => 'Valid Job',
+                'description' => 'Valid Description',
+                'location' => '',
+                'salary' => '50000',
+            ]],
+            'invalid location: too long' => [[
+                'title' => 'Valid Job',
+                'description' => 'Valid Description',
+                'location' => str_repeat('L', 256),
+                'salary' => '50000',
+            ]],
+            'invalid salary: too long' => [[
+                'title' => 'Valid Job',
+                'description' => 'Valid Description',
+                'location' => 'Valid Location',
+                'salary' => str_repeat('1', 256),
+            ]],
+            'invalid skills: too long' => [[
+                'title' => 'Valid Job',
+                'description' => 'Valid Description',
+                'location' => 'Valid Location',
+                'salary' => '50000',
+                'skills' => str_repeat('Skill, ', 50),
+            ]],
+        ];
+    }
+
+    public function testCreateMultipleJobOffers(): void
+    {
+        $initialCount = JobOffer::where('recruiter_id', $this->recruiter->id)->count();
+
+        $jobOffers = JobOffer::factory()
+            ->count(5)
+            ->create([
+                'recruiter_id' => $this->recruiter->id
+            ]);
+        $this->assertEquals($initialCount + 5, JobOffer::where('recruiter_id', $this->recruiter->id)->count());
+
+        foreach ($jobOffers as $jobOffer) {
+            $this->assertDatabaseHas('job_offers', [
+                'id' => $jobOffer->id,
+                'recruiter_id' => $this->recruiter->id
+            ]);
+        }
+    }
+
+  
+}

--- a/tests/Feature/Controller/Job/JobOfferControllerTest.php
+++ b/tests/Feature/Controller/Job/JobOfferControllerTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controller\Job;
+
+use Tests\TestCase;
+use App\Http\Controllers\api\Job\JobOfferController;
+
+
+class JobOfferControllerTest extends TestCase
+{
+    public function testIfJobOfferControllerExists(): void
+    {
+        $this->assertTrue(class_exists(JobOfferController::class));
+    }
+}

--- a/tests/Unit/Model/Job/JobOfferModelTest.php
+++ b/tests/Unit/Model/Job/JobOfferModelTest.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Model\Job;
+
+use App\Models\JobOffer;
+use Tests\TestCase; 
+class JobOfferModelTest extends TestCase
+{
+    public function testIfJobOfferModelExists(): void
+    {
+        $this->assertTrue(class_exists(JobOffer::class));
+    }
+}


### PR DESCRIPTION
### Create Job Offer Command Implementation:
**💻  Creation of create:job-offer command:**

- Custom Artisan command to create job offers from the terminal.
- Collects offer data: recruiter_id, title, description, location, salary, skills.
- Validates the data with CreateJobOfferRequest and shows a preview before confirmation.

**🧑‍💻 JobOfferController:**

- Handles the logic for creating the job offer and inserting it into the database.

**🗄️ Database Migration:**

- Used migration for the job_offers table with relevant fields and foreign keys.

**🔒  Validation in CreateJobOfferRequest:**

- Defines validation rules to ensure data integrity.

**🧪 Tests:**

- Added tests to verify correct functionality of the command, validation, and controller.
- Validated data collection and error handling with invalid data.

**🔀 Complexities:**

- Real-time validation through the console: Ensuring real-time validation feedback while using Artisan in the terminal.
- Simulation in tests: Simulating and testing console input/output and validating user responses in tests, including the handling of validation errors.